### PR TITLE
fix: bugs with MetaDataset & random crop + add dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ WAVDataset(
     path: Union[str, Sequence[str]], # Path or list of paths from which to load files
     recursive: bool = False # Recursively load files from provided paths
     sample_rate: bool = False, # Specify sample rate to convert files to on read
-    optimized_random_crop_size: int = None, # Load small portions of files randomly
+    random_crop_size: int = None, # Load small portions of files randomly
     transforms: Optional[Callable] = None, # Transforms to apply to audio files
     check_silence: bool = True # Discards silent samples if true
 )

--- a/audio_data_pytorch/datasets/meta_dataset.py
+++ b/audio_data_pytorch/datasets/meta_dataset.py
@@ -25,7 +25,7 @@ class MetaDataset(WAVDataset):
         self.max_genres = max_genres
         self.metadata_mapping_path = metadata_mapping_path
 
-        super().__init__(with_idx=True, **kwargs)
+        super().__init__(with_ID3=True, **kwargs)
 
         if metadata_mapping_path:
             # Create or load genre/artist -> id mapping file.
@@ -82,9 +82,7 @@ class MetaDataset(WAVDataset):
         self, idx: int
     ) -> Union[Tensor, Tuple[Tensor, Tensor], Tuple[Tensor, List[str], List[str]]]:
         # Get waveform
-        waveform, idx = super().__getitem__(idx)  # type: ignore
-        # Get ID3 data
-        tag = TinyTag.get(self.wavs[idx])
+        waveform, tag = super().__getitem__(idx)  # type: ignore
         # Split artists by separators like "feat"
         artists = split_artists(tag.artist or "")
         # Split genres by ","

--- a/audio_data_pytorch/datasets/meta_dataset.py
+++ b/audio_data_pytorch/datasets/meta_dataset.py
@@ -43,8 +43,10 @@ class MetaDataset(WAVDataset):
                         print("Found invalid mapping file:", e)
             if not hasattr(self, "mappings"):
                 self.mappings = self.generate_mappings(metadata_mapping_path)
-            print("Artists:", len(self.mappings["artists"]))
-            print("Genres:", len(self.mappings["genres"]))
+            self.num_artists = len(self.mappings["artists"])
+            self.num_genres = len(self.mappings["genres"])
+            print("Artists:", self.num_artists)
+            print("Genres:", self.num_genres)
 
     def generate_mappings(self, metadata_mapping_path):
         mappings = {"artists": bidict(), "genres": bidict()}

--- a/audio_data_pytorch/datasets/meta_dataset.py
+++ b/audio_data_pytorch/datasets/meta_dataset.py
@@ -75,7 +75,10 @@ class MetaDataset(WAVDataset):
                         mappings.setdefault("genres", {}).setdefault(genre, genre_id)
                         genre_id += 1
             # Convert and save newly generated mappings to disk
-            dict_mappings = {"artists": dict(mappings['artists']), "genres": dict(mappings['genres'])}
+            dict_mappings = {
+                "artists": dict(mappings["artists"]),
+                "genres": dict(mappings["genres"]),
+            }
             json.dump(dict_mappings, openfile)
         return mappings
 
@@ -83,6 +86,7 @@ class MetaDataset(WAVDataset):
         self, idx: int
     ) -> Union[Tensor, Tuple[Tensor, Tensor], Tuple[Tensor, List[str], List[str]]]:
         # Get waveform
+        tag: TinyTag = None
         waveform, tag = super().__getitem__(idx)  # type: ignore
         # Split artists by separators like "feat"
         artists = split_artists(tag.artist or "")

--- a/audio_data_pytorch/datasets/meta_dataset.py
+++ b/audio_data_pytorch/datasets/meta_dataset.py
@@ -41,7 +41,7 @@ class MetaDataset(WAVDataset):
                         print("Mappings loaded.")
                     except JSONDecodeError as e:
                         print("Found invalid mapping file:", e)
-            if self.mappings == {}:
+            if not hasattr(self, "mappings"):
                 self.mappings = self.generate_mappings(metadata_mapping_path)
             print("Artists:", len(self.mappings["artists"]))
             print("Genres:", len(self.mappings["genres"]))
@@ -58,7 +58,7 @@ class MetaDataset(WAVDataset):
                 try:
                     tag = TinyTag.get(wav)
                 except Exception:
-                    print("broken file")
+                    print("Skipping corrupt sample: ", wav)
                     continue
                 # Create artist/genre arrays from ID3 artist/genre strings.
                 artists = split_artists(tag.artist or "")
@@ -74,8 +74,9 @@ class MetaDataset(WAVDataset):
                     if not ("genres" in mappings and genre in mappings["genres"]):
                         mappings.setdefault("genres", {}).setdefault(genre, genre_id)
                         genre_id += 1
-            # Save newly generated mappings to disk
-            json.dump(mappings, openfile)
+            # Convert and save newly generated mappings to disk
+            dict_mappings = {"artists": dict(mappings['artists']), "genres": dict(mappings['genres'])}
+            json.dump(dict_mappings, openfile)
         return mappings
 
     def __getitem__(

--- a/audio_data_pytorch/datasets/wav_dataset.py
+++ b/audio_data_pytorch/datasets/wav_dataset.py
@@ -27,7 +27,7 @@ class WAVDataset(Dataset):
         recursive: bool = False,
         transforms: Optional[Callable] = None,
         sample_rate: Optional[int] = None,
-        optimized_random_crop_size: int = None,
+        random_crop_size: int = None,
         check_silence: bool = True,
         with_ID3: bool = False,
     ):
@@ -37,9 +37,9 @@ class WAVDataset(Dataset):
         self.sample_rate = sample_rate
         self.check_silence = check_silence
         self.with_ID3 = with_ID3
-        self.optimized_random_crop_size = optimized_random_crop_size
+        self.random_crop_size = random_crop_size
         assert (
-            not optimized_random_crop_size or sample_rate
+            not random_crop_size or sample_rate
         ), "Optimized random crop requires sample_rate to be set."
 
     # Instead of loading the whole file and chopping out our crop,
@@ -53,7 +53,7 @@ class WAVDataset(Dataset):
         # Calculate correct number of samples to read based on actual
         # and intended sample rate
         ratio = sample_rate / self.sample_rate
-        crop_size = math.ceil(self.optimized_random_crop_size * ratio)  # type: ignore
+        crop_size = math.ceil(self.random_crop_size * ratio)  # type: ignore
         frame_offset = random.randint(0, max(length - crop_size, 0))
 
         # Load the samples
@@ -97,7 +97,7 @@ class WAVDataset(Dataset):
                     tag = TinyTag.get(self.wavs[idx])
 
                 # Read with optimized crop if needed
-                if hasattr(self, "optimized_random_crop_size"):
+                if hasattr(self, "random_crop_size"):
                     waveform, sample_rate = self.optimized_random_crop(int(idx))
                 else:
                     waveform, sample_rate = torchaudio.load(filepath=self.wavs[idx])
@@ -112,8 +112,8 @@ class WAVDataset(Dataset):
                 )(waveform)
 
                 # Downsampling can result in slightly different sizes.
-                if hasattr(self, "optimized_random_crop_size"):
-                    waveform = waveform[:, : self.optimized_random_crop_size]
+                if hasattr(self, "random_crop_size"):
+                    waveform = waveform[:, : self.random_crop_size]
 
             # Apply other transforms
             if self.transforms:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ setup(
         "aiohttp",
         "webdataset",
         "tinytag",
-        "bidict"
+        "bidict",
+        "pandas",
+        "yt_dlp"
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This PR fixes a few issues I ran into while setting things up with ZQEvans' dataset.

The dataloader could cause a crash in certain cases...
- When using `optimized_random_crop` with certain sample rates
- If a sample's audio was valid but ID3 tags were invalid.
- When mappings had not yet been generated
- When attempting to load a corrupt audio sample.
- When attempting to load an audio sample with `optimized_random_crop` disabled(?)

Additionally, while `pandas` and `yt_dlp` are required to import the library, they previously weren't listed in dependencies.